### PR TITLE
ci(dependabot): schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,10 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
+      day: 'saturday'
+      time: '10:00'
+      timezone: 'Asia/Tokyo'
     assignees:
       - 'jnicrimi'
     reviewers:
@@ -13,7 +16,10 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
+      day: 'saturday'
+      time: '10:00'
+      timezone: 'Asia/Tokyo'
     assignees:
       - 'jnicrimi'
     reviewers:


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Chore: `.github/dependabot.yml`の更新。パッケージエコシステムの更新間隔が毎日から週に1回、土曜日の10:00（Asia/Tokyoタイムゾーン）に変更されました。これにより、開発者はパッケージの更新をより効率的に管理できます。npmとgithub-actionsの更新に対するアサインとレビュワーは変わりません。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->